### PR TITLE
Fixed missing QButtonGroup include for Qt 5.11

### DIFF
--- a/src/settings.h
+++ b/src/settings.h
@@ -9,6 +9,7 @@
 #define QBAT_SETTINGS_H
 
 #include <QDialog>
+#include <QButtonGroup>
 #include "ui_settingsdialog.h"
 #include "common.h"
 


### PR DESCRIPTION
Fixes the following compilation error:

```
In file included from ../src/powermanager.cpp:11:
../src/settings.h:20:16: error: field ‘colorSelectButtons’ has incomplete type ‘QButtonGroup’
   QButtonGroup colorSelectButtons;
                ^~~~~~~~~~~~~~~~~~
In file included from /usr/include/qt/QtWidgets/qcheckbox.h:44,
                 from /usr/include/qt/QtWidgets/QCheckBox:1,
                 from ./ui_settingsdialog.h:14,
                 from ../src/settings.h:12,
                 from ../src/powermanager.cpp:11:
/usr/include/qt/QtWidgets/qabstractbutton.h:53:7: note: forward declaration of ‘class QButtonGroup’
 class QButtonGroup;
```